### PR TITLE
Change default CLI name to `luau-analyze`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,8 +91,8 @@ class Extension {
         if (command) {
             AnalyzerCommand = command as string;
         } else {
-            vscode.window.showErrorMessage("Luau Analyzer command not found! Setting command to: `luau-analyzer`");
-            AnalyzerCommand = "luau-analyzer";
+            vscode.window.showErrorMessage("Luau Analyzer command not found! Setting command to: `luau-analyze`");
+            AnalyzerCommand = "luau-analyze";
             config.update("analyzerCommand", AnalyzerCommand, true);
         }
     }


### PR DESCRIPTION
The default name for the CLI is normally `luau-analyze`, not `luau-analyzer` (this is also what https://github.com/zeux/SublimeLinter-luau uses)

In general, the difference between `Luau-Analyzer` (the extension name) and `luau-analyze` (the binary names) may be a bit confusing, could be something to look into.