### PR TITLE
Add "read filesystem only" config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,59 +12,64 @@
 		"onLanguage:lua"
 	],
 	"contributes": {
-        "configuration": {
-            "title": "Vscode-Analyzer-Luau",
-            "properties": {
-                "vscode-luau-analyzer.usesLuauAnalyzeRojo": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Should the extension make use of luau-analyzer-rojo? See: [luau-analyze-rojo](https://github.com/JohnnyMorganz/luau-analyze-rojo)"
-                },
-                "vscode-luau-analyzer.analyzerCommand": {
-                    "type": "string",
-                    "default": "luau-analyze",
-                    "description": "Specifies analyzer command. Analyzer must be in PATH."
-                },
-                "vscode-luau-analyzer.rojoProject": {
-                    "type": "string",
-                    "default": "default.project.json",
-                    "markdownDescription": "Specifies the rojo project. (Note: `Uses Luau Analyze Rojo` must be set to true!)"
-                },
-                "vscode-luau-analyzer.typeDefinition": {
-                    "type": "string",
-                    "default": "globalTypes.d.lua",
-                    "markdownDescription": "Specifies the global type definition. (Note: `Uses Luau Analyze Rojo` must be set to true!)"
-                },
-                "vscode-luau-analyzer.ignoredPaths": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default:": [
-                        "**/_Index/**"
-                    ],
-                    "markdownDescription": "Specifies the ignored paths that wont be used when sharing diagnostics. (Regex is supported!)"
-                }
-            }
-        },
-        "commands": [
-            {
-                "command": "vscode-luau-analyzer.showSourceMap",
-                "title": "Show Dumped Source Map",
-                "category": "Analyzer-Lua"
-            },
-            {
-                "command": "vscode-luau-analyzer.showAnnotations",
-                "title": "Show Annotations",
-                "category": "Analyzer-Lua"
-            },
-            {
-                "command": "vscode-luau-analyzer.installTypes",
-                "title": "Install Types",
-                "category": "Analyzer-Lua"
-            }
-        ]
-    },
+		"configuration": {
+			"title": "Vscode-Analyzer-Luau",
+			"properties": {
+				"vscode-luau-analyzer.usesLuauAnalyzeRojo": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Should the extension make use of luau-analyzer-rojo? See: [luau-analyze-rojo](https://github.com/JohnnyMorganz/luau-analyze-rojo)"
+				},
+				"vscode-luau-analyzer.analyzerCommand": {
+					"type": "string",
+					"default": "luau-analyze",
+					"description": "Specifies analyzer command. Analyzer must be in PATH."
+				},
+				"vscode-luau-analyzer.rojoProject": {
+					"type": "string",
+					"default": "default.project.json",
+					"markdownDescription": "Specifies the rojo project. (Note: `Uses Luau Analyze Rojo` must be set to true!)"
+				},
+				"vscode-luau-analyzer.typeDefinition": {
+					"type": "string",
+					"default": "globalTypes.d.lua",
+					"markdownDescription": "Specifies the global type definition. (Note: `Uses Luau Analyze Rojo` must be set to true!)"
+				},
+				"vscode-luau-analyzer.readFilesystemOnly": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Specifies whether to act on the unsaved file contents, or only act on the saved file contents. When true, the analyzer will only run when saving instead of when typing."
+				},
+				"vscode-luau-analyzer.ignoredPaths": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default:": [
+						"**/_Index/**"
+					],
+					"markdownDescription": "Specifies the ignored paths that wont be used when sharing diagnostics. (Regex is supported!)"
+				}
+			}
+		},
+		"commands": [
+			{
+				"command": "vscode-luau-analyzer.showSourceMap",
+				"title": "Show Dumped Source Map",
+				"category": "Analyzer-Lua"
+			},
+			{
+				"command": "vscode-luau-analyzer.showAnnotations",
+				"title": "Show Annotations",
+				"category": "Analyzer-Lua"
+			},
+			{
+				"command": "vscode-luau-analyzer.installTypes",
+				"title": "Install Types",
+				"category": "Analyzer-Lua"
+			}
+		]
+	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",

--- a/src/FileAnalyzer.ts
+++ b/src/FileAnalyzer.ts
@@ -40,8 +40,8 @@ export default class FileAnalyzer {
 
             args.push("--formatter=plain", "-")
         }
-        
-        
+
+        this.args = args
         return args;
     }
     

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ export let ExtensionSettings: {
     UsesLuauAnalyzeRojo: boolean,
     AnalyzerCommand: string,
     IgnoredPaths: string[],
+    ReadFilesystemOnly: boolean,
 };
 
 let SourceMap: string = "";
@@ -112,11 +113,12 @@ class ExtensionClass {
         let config = vscode.workspace.getConfiguration(ConfigurationName);
         
         let newSettings = {
-            RojoProjectPath: config.get("rojoProject", "defualt.project.json"),
+            RojoProjectPath: config.get("rojoProject", "default.project.json"),
             TypeDefsPath: config.get("typeDefinition", "globalTypes.d.lua"),
             UsesLuauAnalyzeRojo: config.get("usesLuauAnalyzeRojo") as boolean,
             AnalyzerCommand: config.get("analyzerCommand", "luau-analyze"),
             IgnoredPaths: config.get("ignoredPaths", []) as string[],
+            ReadFilesystemOnly: config.get("readFilesystemOnly", false),
         }
         
         ExtensionSettings = newSettings;
@@ -147,7 +149,16 @@ class ExtensionClass {
                 this.updateDiagnostics(document);
             }),
             vscode.workspace.onDidChangeTextDocument((event) => {
-                this.updateDiagnostics(event.document);
+                let config = vscode.workspace.getConfiguration(ConfigurationName);
+                if (config.get("readFilesystemOnly") === false) {
+                    this.updateDiagnostics(event.document);
+                }
+            }),
+            vscode.workspace.onDidSaveTextDocument((document) => {
+                let config = vscode.workspace.getConfiguration(ConfigurationName);
+                if (config.get("readFilesystemOnly") === true) {
+                    this.updateDiagnostics(document);
+                }
             }),
             vscode.workspace.onDidCloseTextDocument((document) => {
                 this.collection.delete(document.uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,14 +149,12 @@ class ExtensionClass {
                 this.updateDiagnostics(document);
             }),
             vscode.workspace.onDidChangeTextDocument((event) => {
-                let config = vscode.workspace.getConfiguration(ConfigurationName);
-                if (config.get("readFilesystemOnly") === false) {
+                if (ExtensionSettings.ReadFilesystemOnly === false) {
                     this.updateDiagnostics(event.document);
                 }
             }),
             vscode.workspace.onDidSaveTextDocument((document) => {
-                let config = vscode.workspace.getConfiguration(ConfigurationName);
-                if (config.get("readFilesystemOnly") === true) {
+                if (ExtensionSettings.ReadFilesystemOnly === true) {
                     this.updateDiagnostics(document);
                 }
             }),


### PR DESCRIPTION
This adds a new setting which
1. Runs the command on the saved file contents, instead of `stdin`. I'm still having trouble with `stdin`, and this is a good fallback for the future in case it breaks again.
2. Only runs the analyzer on save so as to reduce the workload on change. Some users were reporting problems with their editor due to the editor waiting on luau-analyze every time they typed (me included!)

---

Sorry for the bigger commit than strictly necessary, it looks like I also:
* Fixed `package.json` which was using mixed tabs and spaces for indentation. My editor did this for me, apparently!
* Fixed a typo on the default project file: `defualt.project.json` -> `default.project.json`