### PR TITLE
Show "caused by" explanations

### DIFF
--- a/src/FileAnalyzer.ts
+++ b/src/FileAnalyzer.ts
@@ -78,7 +78,7 @@ export default class FileAnalyzer {
         let errors = this.executeAnalyzer();
         let newDiagnostics: vscode.Diagnostic[] = [];
 
-        let lineRegex = /^(.*):(\d*):(\d*-\d*): \(.*\) (\w*): (.*(?:\r?\ncaused by:\r?\n(?:  .+)+)?)/mg;
+        let lineRegex = /^(.*):(\d*):(\d*-\d*): \(.*\) (\w*): (.*(?:\r?\ncaused by:\r?\n(?:  .+)+)*)/mg;
         // This makes use of two features to grab each line plus, in some cases,
         // following lines:
         // * The `m` multiline flag: this is used to make `^` count as the start


### PR DESCRIPTION
This PR adds support for showing the "caused by" text that some errors report.

For example, the following list of errors includes a "caused by" explanation that this extension does not show in the diagnostics window:

```plain
src/lib/SaveManager/SaveManager.specgen.lua:514:33-41: (W0) TypeError: Type 'a' could not be converted into 'string'
src/lib/SaveManager/SaveManager.specgen.lua:514:33-41: (W0) TypeError: Argument count mismatch. Function expects 3 arguments, but only 2 are specified
src/lib/SaveManager/SaveManager.specgen.lua:470:35-100: (W0) TypeError: Type '({| [a]: string |}, {{string}}, a, a) -> (...any)' could not be converted into '({| [a]: string |}, {{string}}, ...any) -> (...any)'
caused by:
  Argument #4 type is not compatible. Generic supertype escaping scope
src/lib/SaveManager/SaveManager.specgen.lua:525:25-39: (W0) TypeError: Key 'new' not found in table 'SaveManager'
src/lib/SaveManager/SaveManager.specgen.lua:545:26-40: (W0) TypeError: Key 'new' not found in table 'SaveManager'
```

This PR accomplishes this by replacing the line split + regex match with a single multiline global regex that attempts to match "caused by" on the next line + following indented lines.