### PR TITLE
Add ability to pass additional arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,14 @@
 						"**/_Index/**"
 					],
 					"markdownDescription": "Specifies the ignored paths that wont be used when sharing diagnostics. (Regex is supported!)"
+				},
+				"vscode-luau-analyzer.additionalArgs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default:": [],
+					"markdownDescription": "Specifies additional arguments to pass to luau-analyze"
 				}
 			}
 		},

--- a/src/FileAnalyzer.ts
+++ b/src/FileAnalyzer.ts
@@ -18,7 +18,7 @@ export default class FileAnalyzer {
     }
     
     rebuildArgs() {
-        let args = [];
+        let args = [...ExtensionSettings.AdditionalArgs];
 
         if (ExtensionSettings.ReadFilesystemOnly) {
             if (ExtensionSettings.UsesLuauAnalyzeRojo == true) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ export let ExtensionSettings: {
     AnalyzerCommand: string,
     IgnoredPaths: string[],
     ReadFilesystemOnly: boolean,
+    AdditionalArgs: string[],
 };
 
 let SourceMap: string = "";
@@ -99,6 +100,7 @@ class ExtensionClass {
             AnalyzerCommand: config.get("analyzerCommand", "luau-analyze"),
             IgnoredPaths: config.get("ignoredPaths", []) as string[],
             ReadFilesystemOnly: config.get("readFilesystemOnly", false),
+            AdditionalArgs: config.get("additionalArgs", []) as string[],
         }
         
         ExtensionSettings = newSettings;


### PR DESCRIPTION
This PR adds the ability to specify additional arguments for `luau-analyze` in the settings. These custom arguments appear *before* the generated arguments.

I was [playing around with some additional options to luau-analyze-rojo](https://github.com/Corecii/luau-analyze-rojo/commit/a533bffa467ac32a1f0f430606c67aa30ff7f8ad) so I needed a way to add those to the extension. I figured being able to add extra arguments may be useful for other reasons, too, or may be useful in the future!